### PR TITLE
Improve UCM reconnection flow

### DIFF
--- a/src/css/unison-theme.css
+++ b/src/css/unison-theme.css
@@ -158,11 +158,11 @@
   --u-color_positive_text-on-element_subdued: var(--u-color_text);
   --u-color_positive_icon-on-element_subdued: var(--color-green-1);
 
-  --u-color_working_element: var(--color-purple-5);
-  --u-color_working_text-on-element: var(--color-purple-2);
-  --u-color_working_icon-on-element: var(--color-purple-2);
-  --u-color_working_element_subdued: var(--color-gray-lighten-60);
-  --u-color_working_text-on-element_subdued: var(--u-color_text);
+  /* [x] */ --u-color_working_element: var(--color-purple-5);
+  /* [x] */ --u-color_working_text-on-element: var(--color-purple-2);
+  /* [x] */ --u-color_working_icon-on-element: var(--color-purple-2);
+  /* [x] */ --u-color_working_element_subdued: var(--color-gray-base);
+  /* [x] */ --u-color_working_text-on-element_subdued: var(--u-color_text);
 
   --u-color_chrome: var(--color-gray-darken-20);
   --u-color_chrome_subdued: var(--color-gray-darken-30);

--- a/src/main.css
+++ b/src/main.css
@@ -8,3 +8,13 @@
 @import "./css/ucm/command-palette-modal.css";
 @import "./css/ucm/ucm-connectivity.css";
 @import "./css/ucm/contextual-tag.css";
+
+.connecting {
+  margin: 16rem auto;
+  width: 32rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  flex-shrink: 0;
+}


### PR DESCRIPTION
* Fix a bug where attempting to retry reconnection on the app level error, it would show the next error on the active screen instead of staying on the app level
* Fix a bug where after success, we werent retrying the connection check as intended
* Add "connecting..." feedback when the user clicks "try again".

Fixes https://github.com/unisonweb/ucm-desktop/issues/10