### PR TITLE
Update the UCM API URL to match new scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,15 +12,10 @@ The goal is a UI that looks like this:
 ---
 
 ## Running 
-UCM desktop requires the UCM CLI to be running on a specific port and with a
-specific UCM token
+UCM desktop requires the UCM CLI to be running, simply start it with the `ucm`
+command:
 ```bash
-UCM_TOKEN=asdf UCM_PORT=4444 ucm --allow-cors-host tauri://localhost
-```
-
-If on Windows (PowerShell), use this command instead:
-```bash
-$env:UCM_TOKEN="asdf"; $env:UCM_PORT="4444"; ucm --allow-cors-host http://tauri.localhost
+ucm
 ```
 
 Then start the UCM Desktop app as you would normally.
@@ -29,7 +24,7 @@ Then start the UCM Desktop app as you would normally.
 When running for development start UCM like so:
 
 ```bash
-UCM_TOKEN=asdf UCM_PORT=4444 ucm --allow-cors-host http://localhost:1420
+ucm --allow-cors-host http://localhost:1420
 ```
 
 Then start the app with:

--- a/src/main.ts
+++ b/src/main.ts
@@ -38,7 +38,7 @@ try {
   const flags = {
     operatingSystem: detectOs(window.navigator),
     basePath: "",
-    apiUrl: "http://127.0.0.1:4444/asdf/api",
+    apiUrl: "http://127.0.0.1:5858/codebase/api",
     workspaceContext: appSettings.workspaceContexts[0],
     theme: appSettings.theme
   };


### PR DESCRIPTION
Update UCM Desktop to connect to the API on
`http://127.0.0.1:5858/codebase/api` reflecting the recent UCM change (https://github.com/unisonweb/unison/pull/5461) to remove the autogenerated port and token in favor of defaults.