### PR TITLE
Update workspace-card css to not specify z-index

### DIFF
--- a/src/css/ucm/workspace/workspace-card.css
+++ b/src/css/ucm/workspace/workspace-card.css
@@ -9,7 +9,6 @@
   gap: 0;
   padding: 0;
   width: var(--c-workspace-card_width);
-  z-index: var(--layer-base);
 
   & .workspace-card_titlebar {
     display: flex;


### PR DESCRIPTION
## Problem

Closes https://github.com/unisonweb/ucm-desktop/issues/36.

`tooltip-bubble` modals are displaying incorrectly with sibling workspace cards.

<img width="748" alt="image" src="https://github.com/user-attachments/assets/f64c5c4f-fec2-408a-8f7b-3c5c3400db7f" />

## Solution

Updates the `workspace-card` css class to not specify `z-index`, allowing the `tooltip-bubble` class to correctly display on top of sibling workspace cards. Based on current css usage, this appears to be a simpler solution than adjusting the `z-index` property of the `tooltip-bubble` class to be higher than the `workspace-card` class:

<img width="745" alt="image" src="https://github.com/user-attachments/assets/d29dde05-7fb4-4d37-a0cf-cb526c2bfd58" />

## Caveats/Notes

I have little context on this application and its conventions, and I may be missing key context on why `workspace-card` has the `z-index` property defined that may make this solution insufficient. I am happy to iterate on this proposal if this solution is not possible.
