### PR TITLE
Fix (implement really...) scroll to on focus

### DIFF
--- a/src/Ucm/Workspace/WorkspaceCard.elm
+++ b/src/Ucm/Workspace/WorkspaceCard.elm
@@ -13,6 +13,7 @@ type alias WorkspaceCard msg =
     , tabList : Maybe (TabList msg)
     , content : List (Html msg)
     , hasFocus : Bool
+    , domId : Maybe String
     }
 
 
@@ -27,6 +28,7 @@ empty =
     , tabList = Nothing
     , content = []
     , hasFocus = False
+    , domId = Nothing
     }
 
 
@@ -68,6 +70,11 @@ withContent content card_ =
     { card_ | content = content }
 
 
+withDomId : String -> WorkspaceCard msg -> WorkspaceCard msg
+withDomId domId card_ =
+    { card_ | domId = Just domId }
+
+
 withTabList : TabList msg -> WorkspaceCard msg -> WorkspaceCard msg
 withTabList tabList card_ =
     { card_ | tabList = Just tabList }
@@ -103,6 +110,7 @@ map f card_ =
     , tabList = Maybe.map (TabList.map f) card_.tabList
     , content = map_ card_.content
     , hasFocus = card_.hasFocus
+    , domId = card_.domId
     }
 
 
@@ -111,7 +119,7 @@ map f card_ =
 
 
 view : WorkspaceCard msg -> Html msg
-view { titleLeft, titleRight, tabList, content, hasFocus } =
+view { titleLeft, titleRight, tabList, content, hasFocus, domId } =
     let
         className =
             if hasFocus then
@@ -131,8 +139,17 @@ view { titleLeft, titleRight, tabList, content, hasFocus } =
             , tabList |> Maybe.map TabList.view |> Maybe.withDefault UI.nothing
             , section [ class "workspace-card_main-content" ] content
             ]
+
+        card_ =
+            case domId of
+                Just domId_ ->
+                    Card.card cardContent
+                        |> Card.withDomId domId_
+
+                Nothing ->
+                    Card.card cardContent
     in
-    Card.card cardContent
+    card_
         |> Card.asContained
         |> Card.withClassName className
         |> Card.view

--- a/src/Ucm/Workspace/WorkspaceItem.elm
+++ b/src/Ucm/Workspace/WorkspaceItem.elm
@@ -11,8 +11,7 @@ import Code.FullyQualifiedName as FQN exposing (FQN)
 import Code.Hash as Hash
 import Http
 import Json.Decode as Decode exposing (field, index)
-import Lib.Decode.Helpers as DecodeH exposing (nonEmptyList)
-import Lib.Util as Util
+import Lib.Decode.Helpers as DecodeH
 import List.Nonempty as NEL
 import Maybe.Extra as MaybeE
 import Ucm.Workspace.WorkspaceItemRef exposing (SearchResultsRef, WorkspaceItemRef(..))

--- a/src/Ucm/Workspace/WorkspaceItemRef.elm
+++ b/src/Ucm/Workspace/WorkspaceItemRef.elm
@@ -25,6 +25,11 @@ toString ref =
             r
 
 
+toDomString : WorkspaceItemRef -> String
+toDomString ref =
+    ref |> toString |> String.replace "." "__"
+
+
 toHumanString : WorkspaceItemRef -> String
 toHumanString ref =
     case ref of

--- a/src/Ucm/Workspace/WorkspacePanes.elm
+++ b/src/Ucm/Workspace/WorkspacePanes.elm
@@ -68,7 +68,7 @@ update config msg model =
         LeftPaneMsg workspacePaneMsg ->
             let
                 ( leftPane, leftPaneCmd, out ) =
-                    WorkspacePane.update config workspacePaneMsg model.left
+                    WorkspacePane.update config "workspace-pane_left" workspacePaneMsg model.left
 
                 focusedPane =
                     case ( out, model.focusedPane ) of
@@ -83,7 +83,7 @@ update config msg model =
         RightPaneMsg workspacePaneMsg ->
             let
                 ( rightPane, rightPaneCmd, out ) =
-                    WorkspacePane.update config workspacePaneMsg model.right
+                    WorkspacePane.update config "workspace-pane_right" workspacePaneMsg model.right
 
                 focusedPane =
                     case ( out, model.focusedPane ) of
@@ -158,14 +158,14 @@ openDefinition config model ref =
         LeftPaneFocus _ ->
             let
                 ( leftPane, leftPaneCmd ) =
-                    WorkspacePane.openDefinition config model.left ref
+                    WorkspacePane.openDefinition config "workspace-pane_left" model.left ref
             in
             ( { model | left = leftPane }, Cmd.map LeftPaneMsg leftPaneCmd )
 
         RightPaneFocus ->
             let
                 ( rightPane, rightPaneCmd ) =
-                    WorkspacePane.openDefinition config model.right ref
+                    WorkspacePane.openDefinition config "workspace-pane_right" model.right ref
             in
             ( { model | right = rightPane }, Cmd.map RightPaneMsg rightPaneCmd )
 
@@ -199,10 +199,10 @@ view : Model -> Html Msg
 view model =
     let
         left isFocused =
-            Html.map LeftPaneMsg (WorkspacePane.view isFocused model.left)
+            Html.map LeftPaneMsg (WorkspacePane.view "workspace-pane_left" isFocused model.left)
 
         right isFocused =
-            Html.map RightPaneMsg (WorkspacePane.view isFocused model.right)
+            Html.map RightPaneMsg (WorkspacePane.view "workspace-pane_right" isFocused model.right)
 
         paneConfig =
             SplitPane.createViewConfig

--- a/src/css/ucm/workspace/workspace-card.css
+++ b/src/css/ucm/workspace/workspace-card.css
@@ -3,7 +3,6 @@
   --c-workspace-card_background: var(--u-color_container_faded);
   --c-workspace-card_width: calc(var(--readable-column-width-medium) + 2rem);
 
-
   display: flex;
   flex-direction: column;
   gap: 0;

--- a/src/css/ucm/workspace/workspace-pane.css
+++ b/src/css/ucm/workspace/workspace-pane.css
@@ -5,8 +5,6 @@
   padding: 0.75rem;
   overflow: auto;
   width: 100%;
-  /*min-width: max-content;*/
-
   container-type: inline-size;
   container-name: workspace-pane;
 


### PR DESCRIPTION
Scrolling to the focused workspace card (usually a newly opened definition) was left half implemented by mistake. This makes sure scrolling to the elements work in the separate panes and with enough top margin to look good.

Address the scrolling portion of this ticket: https://github.com/unisonweb/unison/issues/5747
