### PR TITLE
Add shift+x keyboard command to close all items

### DIFF
--- a/src/Ucm/Workspace/WorkspacePane.elm
+++ b/src/Ucm/Workspace/WorkspacePane.elm
@@ -352,6 +352,11 @@ handleKeyboardShortcut paneId model shortcut =
         Chord Shift (K _) ->
             moveUp
 
+        Chord Shift (X _) ->
+            ( { model | workspaceItems = WorkspaceItems.empty }
+            , Cmd.none
+            )
+
         Sequence _ ArrowDown ->
             nextDefinition
 


### PR DESCRIPTION
Add a new keyboard command (shift+x) that closes all open definitions in a pane.

Addresses part of https://github.com/unisonweb/unison/issues/5747