### PR TITLE
Add about modal with version

### DIFF
--- a/src/Ucm/AppContext.elm
+++ b/src/Ucm/AppContext.elm
@@ -22,6 +22,7 @@ type alias AppContext =
     , ucmConnectivity : UcmConnectivity
     , theme : String
     , assets : Assets
+    , version : String
     }
 
 
@@ -32,6 +33,7 @@ type alias Flags =
     , workspaceContext : Value
     , theme : String
     , assets : Assets
+    , version : String
     }
 
 
@@ -43,6 +45,7 @@ init flags =
     , ucmConnectivity = Connecting
     , theme = flags.theme
     , assets = flags.assets
+    , version = flags.version
     }
 
 

--- a/src/Ucm/WelcomeScreen.elm
+++ b/src/Ucm/WelcomeScreen.elm
@@ -236,4 +236,4 @@ view appContext model =
             ]
         |> Window.withoutTitlebarBorder
         |> Window.withContent windowContent
-        |> Window.view WindowMsg model.window
+        |> Window.view appContext WindowMsg model.window

--- a/src/Ucm/WorkspaceScreen.elm
+++ b/src/Ucm/WorkspaceScreen.elm
@@ -396,11 +396,11 @@ subscriptions model =
     let
         activeSub =
             case model.modal of
-                NoModal ->
-                    Sub.map WorkspacePanesMsg (WorkspacePanes.subscriptions model.panes)
-
                 CommandPaletteModal m ->
                     Sub.map CommandPaletteMsg (CommandPalette.subscriptions m)
+
+                _ ->
+                    Sub.map WorkspacePanesMsg (WorkspacePanes.subscriptions model.panes)
     in
     Sub.batch
         [ Sub.map WindowMsg (Window.subscriptions model.window)
@@ -525,7 +525,8 @@ view appContext model =
                 window
 
         footerRight =
-            [ UcmConnectivity.view appContext.ucmConnectivity ]
+            [ UcmConnectivity.view appContext.ucmConnectivity
+            ]
 
         window__ =
             case model.modal of
@@ -546,4 +547,4 @@ view appContext model =
         |> Window.withFooterLeft (footerLeft model)
         |> Window.withFooterRight footerRight
         |> Window.withContent content
-        |> Window.view WindowMsg model.window
+        |> Window.view appContext WindowMsg model.window

--- a/src/css/ucm/about-modal.css
+++ b/src/css/ucm/about-modal.css
@@ -1,0 +1,64 @@
+#about-modal {
+  --c-about-modal_background: var(--color-gray-darken-10);
+
+  border-radius: var(--border-radius-base);
+  border: 1px solid var(--u-color_border);
+  box-shadow: 
+    0 0.25rem 0.25rem 0 var(--color-gray-darken-30-20pct),
+    0 0 0 1px var(--color-gray-darken-30));
+  width: 14rem;
+  background: var(--c-about-modal_background);
+
+  & .modal-content {
+    padding: 1rem 0;
+  }
+
+  & .modal-content .about {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    justify-content: center;
+    align-items: center;
+    position: relative;
+  }
+
+  & .modal-content .about img {
+    position: relative;
+    width: 5rem;
+    height: 5rem;
+    z-index: 1;
+  }
+
+  & .modal-content .about::after {
+    position: absolute;
+    left: 25%;
+    top: -1rem;
+    content: " ";
+    width: 7rem;
+    height: 7rem;
+    background: radial-gradient(circle closest-side, var(--color-gray-base), var(--c-about-modal_background));
+    opacity: 0.5;
+    z-index: 0;
+  }
+
+  & .modal-content .about h2 {
+    font-size: var(--font-size-large);
+  }
+
+  & .modal-content .about p {
+    text-align: center;
+    font-size: var(--font-size-small);
+    color: var(--u-color_text_subdued);
+  }
+
+
+
+  & .info {
+    font-size: var(--font-size-medium);
+  }
+
+  & .copyright {
+    font-size: var(--font-size-extra-small);
+    color: var(--u-color_text_subdued);
+  }
+}

--- a/src/main.css
+++ b/src/main.css
@@ -8,6 +8,7 @@
 @import "./css/ucm/welcome-screen.css";
 @import "./css/ucm/workspace-screen.css";
 @import "./css/ucm/command-palette-modal.css";
+@import "./css/ucm/about-modal.css";
 @import "./css/ucm/ucm-connectivity.css";
 @import "./css/ucm/contextual-tag.css";
 

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -16,6 +16,7 @@ import * as AppError from "./Ucm/AppError";
 import * as AppSettings from "./Ucm/AppSettings";
 import * as Theme from "./Ucm/Theme";
 import appIcon from "./assets/app-icon.png";
+import pack from "../package.json";
 
 const assets = {
   appIcon,
@@ -45,6 +46,7 @@ try {
     workspaceContext: appSettings.workspaceContexts[0],
     theme: appSettings.theme,
     assets,
+    version: pack.version,
   };
 
   const app = Elm.Main.init({ flags });


### PR DESCRIPTION
Add a new about modal accessible from the settings menu. The about menu shows the app version.

![CleanShot 2025-06-16 at 10 58 03@2x](https://github.com/user-attachments/assets/368b7e22-0172-430a-bddd-8ceabe64c64a)

Fixes #33 