### PR TITLE
Update card controls

### DIFF
--- a/elm-git.json
+++ b/elm-git.json
@@ -1,7 +1,7 @@
 {
     "git-dependencies": {
         "direct": {
-            "https://github.com/unisonweb/ui-core": "938436b750d79786bf1f0dd7612439284e021462"
+            "https://github.com/unisonweb/ui-core": "b267d4004272c435a2167e9846142256c30eaa1c"
         },
         "indirect": {}
     }

--- a/src/Code2/Workspace/WorkspaceCard.elm
+++ b/src/Code2/Workspace/WorkspaceCard.elm
@@ -1,11 +1,11 @@
 module Code2.Workspace.WorkspaceCard exposing (..)
 
 import Code.ProjectDependency as ProjectDependency exposing (ProjectDependency)
+import Code2.Workspace.WorkspaceCardTitlebarButton as TitlebarButton exposing (titlebarButton)
 import Html exposing (Html, div, header, section, span, text)
 import Html.Attributes exposing (class)
 import Lib.OperatingSystem exposing (OperatingSystem)
 import UI
-import UI.Button as Button
 import UI.Card as Card
 import UI.Click as Click exposing (Click)
 import UI.ContextualTag as ContextualTag
@@ -13,7 +13,6 @@ import UI.Icon as Icon exposing (Icon)
 import UI.KeyboardShortcut as KeyboardShortcut exposing (KeyboardShortcut(..), single)
 import UI.KeyboardShortcut.Key as Key exposing (letter)
 import UI.TabList as TabList exposing (TabList)
-import UI.Tooltip as Tooltip
 
 
 type alias WorkspaceCard msg =
@@ -44,7 +43,7 @@ empty =
     , domId = Nothing
     , click = Click.disabled
     , close = Nothing
-    , isFolded = True
+    , isFolded = False
     , toggleFold = Nothing
     }
 
@@ -199,21 +198,6 @@ consIf x isTrue xs =
         xs
 
 
-titlebarButton : msg -> Icon msg -> Html msg -> Html msg
-titlebarButton onClick icon tooltipContent =
-    Tooltip.rich tooltipContent
-        |> Tooltip.tooltip
-        |> Tooltip.below
-        |> Tooltip.withArrow Tooltip.End
-        |> Tooltip.view
-            (Button.icon onClick icon
-                |> Button.stopPropagation
-                |> Button.subdued
-                |> Button.small
-                |> Button.view
-            )
-
-
 view : OperatingSystem -> WorkspaceCard msg -> Html msg
 view os { titleLeft, titleRight, tabList, content, hasFocus, domId, click, close, isFolded, toggleFold } =
     let
@@ -231,13 +215,15 @@ view os { titleLeft, titleRight, tabList, content, hasFocus, domId, click, close
                 Just closeMsg ->
                     [ titlebarButton closeMsg
                         Icon.x
-                        (div [ class "tooltip-with-shortcut" ]
-                            [ text "Close"
-                            , KeyboardShortcut.viewSimple os (single (letter Key.X))
-                            , text "Close all:"
-                            , KeyboardShortcut.viewSimple os (Chord Key.Shift (letter Key.X))
-                            ]
-                        )
+                        |> TitlebarButton.withLeftOfTooltip
+                            (div [ class "tooltip-with-shortcut" ]
+                                [ text "Close"
+                                , KeyboardShortcut.viewSimple os (single (letter Key.X))
+                                , text "Close all:"
+                                , KeyboardShortcut.viewSimple os (Chord Key.Shift (letter Key.X))
+                                ]
+                            )
+                        |> TitlebarButton.view
                     ]
 
         toggleFold_ =
@@ -248,13 +234,15 @@ view os { titleLeft, titleRight, tabList, content, hasFocus, domId, click, close
                 Just toggle ->
                     [ titlebarButton toggle
                         (toggleFoldedIcon isFolded)
-                        (div [ class "tooltip-with-shortcut" ]
-                            [ text "Toggle fold"
-                            , KeyboardShortcut.viewSimple os (single (letter Key.Z))
-                            , text "Toggle all:"
-                            , KeyboardShortcut.viewSimple os (Chord Key.Shift (letter Key.Z))
-                            ]
-                        )
+                        |> TitlebarButton.withLeftOfTooltip
+                            (div [ class "tooltip-with-shortcut" ]
+                                [ text "Toggle fold"
+                                , KeyboardShortcut.viewSimple os (single (letter Key.Z))
+                                , text "Toggle all:"
+                                , KeyboardShortcut.viewSimple os (Chord Key.Shift (letter Key.Z))
+                                ]
+                            )
+                        |> TitlebarButton.view
                     ]
 
         titleRight_ =

--- a/src/Code2/Workspace/WorkspaceCardTitlebarButton.elm
+++ b/src/Code2/Workspace/WorkspaceCardTitlebarButton.elm
@@ -1,0 +1,63 @@
+module Code2.Workspace.WorkspaceCardTitlebarButton exposing (..)
+
+import Html exposing (Html)
+import UI.Button as Button
+import UI.Icon exposing (Icon)
+import UI.Tooltip as Tooltip
+
+
+type TitlebarTooltip msg
+    = NoTooltip
+    | LeftOf (Html msg)
+    | RightOf (Html msg)
+
+
+type alias TitlebarButton msg =
+    { icon : Icon msg
+    , onClick : msg
+    , tooltip : TitlebarTooltip msg
+    }
+
+
+titlebarButton : msg -> Icon msg -> TitlebarButton msg
+titlebarButton onClick icon =
+    { onClick = onClick, icon = icon, tooltip = NoTooltip }
+
+
+withLeftOfTooltip : Html msg -> TitlebarButton msg -> TitlebarButton msg
+withLeftOfTooltip content titlebarButton_ =
+    { titlebarButton_ | tooltip = LeftOf content }
+
+
+withRightOfTooltip : Html msg -> TitlebarButton msg -> TitlebarButton msg
+withRightOfTooltip content titlebarButton_ =
+    { titlebarButton_ | tooltip = RightOf content }
+
+
+view : TitlebarButton msg -> Html msg
+view { icon, onClick, tooltip } =
+    let
+        button =
+            Button.icon onClick icon
+                |> Button.stopPropagation
+                |> Button.subdued
+                |> Button.small
+                |> Button.view
+    in
+    case tooltip of
+        NoTooltip ->
+            button
+
+        LeftOf tooltipContent ->
+            Tooltip.rich tooltipContent
+                |> Tooltip.tooltip
+                |> Tooltip.below
+                |> Tooltip.withArrow Tooltip.End
+                |> Tooltip.view button
+
+        RightOf tooltipContent ->
+            Tooltip.rich tooltipContent
+                |> Tooltip.tooltip
+                |> Tooltip.below
+                |> Tooltip.withArrow Tooltip.Start
+                |> Tooltip.view button

--- a/src/Code2/Workspace/WorkspaceItemRef.elm
+++ b/src/Code2/Workspace/WorkspaceItemRef.elm
@@ -33,13 +33,13 @@ toString : WorkspaceItemRef -> String
 toString ref =
     case ref of
         DefinitionItemRef r ->
-            Reference.toString r
+            "Definition: " ++ Reference.toString r
 
         SearchResultsItemRef (SearchResultsRef r) ->
-            r
+            "Search results:" ++ r
 
         DependentsItemRef r ->
-            Reference.toString r
+            "Dependents of :" ++ Reference.toString r
 
 
 toDomString : WorkspaceItemRef -> String

--- a/src/Code2/Workspace/WorkspacePane.elm
+++ b/src/Code2/Workspace/WorkspacePane.elm
@@ -27,7 +27,7 @@ import UI.Button as Button
 import UI.Click as Click
 import UI.Icon as Icon
 import UI.KeyboardShortcut as KeyboardShortcut exposing (KeyboardShortcut(..))
-import UI.KeyboardShortcut.Key as Key exposing (Key(..))
+import UI.KeyboardShortcut.Key exposing (Key(..))
 import UI.KeyboardShortcut.KeyboardEvent as KeyboardEvent
 import UI.Placeholder as Placeholder
 import UI.StatusIndicator as StatusIndicator

--- a/src/Code2/Workspace/WorkspacePane.elm
+++ b/src/Code2/Workspace/WorkspacePane.elm
@@ -21,11 +21,13 @@ import Lib.HttpApi as HttpApi exposing (ApiRequest, HttpResult)
 import Lib.OperatingSystem exposing (OperatingSystem)
 import Lib.ScrollTo as ScrollTo
 import Lib.Util as Util
+import Set exposing (Set)
+import Set.Extra as SetE
 import UI.Button as Button
 import UI.Click as Click
 import UI.Icon as Icon
 import UI.KeyboardShortcut as KeyboardShortcut exposing (KeyboardShortcut(..))
-import UI.KeyboardShortcut.Key exposing (Key(..))
+import UI.KeyboardShortcut.Key as Key exposing (Key(..))
 import UI.KeyboardShortcut.KeyboardEvent as KeyboardEvent
 import UI.Placeholder as Placeholder
 import UI.StatusIndicator as StatusIndicator
@@ -38,6 +40,7 @@ import UI.StatusIndicator as StatusIndicator
 type alias Model =
     { workspaceItems : WorkspaceItems
     , definitionSummaryTooltip : DefinitionSummaryTooltip.Model
+    , collapsedItems : Set String -- Serialized WorkspaceItemRef
     , keyboardShortcut : KeyboardShortcut.Model
     }
 
@@ -46,6 +49,7 @@ init : OperatingSystem -> ( Model, Cmd Msg )
 init os =
     ( { workspaceItems = WorkspaceItems.init Nothing
       , definitionSummaryTooltip = DefinitionSummaryTooltip.init
+      , collapsedItems = Set.empty
       , keyboardShortcut = KeyboardShortcut.init os
       }
     , Cmd.none
@@ -66,6 +70,7 @@ type Msg
     | OpenDefinition Reference
     | ShowDependentsOf { wsRef : WorkspaceItemRef, defItem : DefinitionItem }
     | ToggleDocFold WorkspaceItemRef Doc.FoldId
+    | ToggleFold WorkspaceItemRef
     | Keydown KeyboardEvent.KeyboardEvent
     | SetFocusedItem WorkspaceItemRef
     | DefinitionSummaryTooltipMsg DefinitionSummaryTooltip.Msg
@@ -159,6 +164,17 @@ update config paneId msg model =
             ( { model
                 | workspaceItems =
                     WorkspaceItems.remove model.workspaceItems ref
+              }
+            , Cmd.none
+            , NoOut
+            )
+
+        ToggleFold ref ->
+            ( { model
+                | collapsedItems =
+                    SetE.toggle
+                        (WorkspaceItemRef.toString ref)
+                        model.collapsedItems
               }
             , Cmd.none
             , NoOut
@@ -473,6 +489,37 @@ handleKeyboardShortcut paneId model shortcut =
             , Cmd.none
             )
 
+        Sequence _ (Z _) ->
+            let
+                collapsedItems =
+                    model.workspaceItems
+                        |> WorkspaceItems.focus
+                        |> Maybe.map WorkspaceItem.reference
+                        |> Maybe.map WorkspaceItemRef.toString
+                        |> Maybe.map (\r -> SetE.toggle r model.collapsedItems)
+                        |> Maybe.withDefault model.collapsedItems
+            in
+            ( { model | collapsedItems = collapsedItems }
+            , Cmd.none
+            )
+
+        Chord Shift (Z _) ->
+            let
+                collapsedItems =
+                    if Set.isEmpty model.collapsedItems then
+                        model.workspaceItems
+                            |> WorkspaceItems.toList
+                            |> List.map WorkspaceItem.reference
+                            |> List.map WorkspaceItemRef.toString
+                            |> Set.fromList
+
+                    else
+                        Set.empty
+            in
+            ( { model | collapsedItems = collapsedItems }
+            , Cmd.none
+            )
+
         _ ->
             ( model, Cmd.none )
 
@@ -532,8 +579,8 @@ syntaxConfig definitionSummaryTooltip =
         |> SyntaxConfig.withSyntaxHelp
 
 
-viewItem : DefinitionSummaryTooltip.Model -> WorkspaceItem -> Bool -> Html Msg
-viewItem definitionSummaryTooltip item isFocused =
+viewItem : OperatingSystem -> Set String -> DefinitionSummaryTooltip.Model -> WorkspaceItem -> Bool -> Html Msg
+viewItem operatingSystem collapsedItems definitionSummaryTooltip item isFocused =
     let
         cardBase =
             WorkspaceCard.empty
@@ -568,6 +615,11 @@ viewItem definitionSummaryTooltip item isFocused =
                             , closeItem = CloseWorkspaceItem wsRef
                             , changeTab = ChangeDefinitionItemTab wsRef
                             , toggleDocFold = ToggleDocFold wsRef
+                            , isFolded =
+                                Set.member
+                                    (WorkspaceItemRef.toString wsRef)
+                                    collapsedItems
+                            , toggleFold = ToggleFold wsRef
                             , showDependents = ShowDependentsOf { wsRef = wsRef, defItem = defItem }
                             }
                     in
@@ -620,11 +672,11 @@ viewItem definitionSummaryTooltip item isFocused =
         |> WorkspaceCard.withDomId domId
         |> WorkspaceCard.withClick
             (Click.onClick (SetFocusedItem (WorkspaceItem.reference item)))
-        |> WorkspaceCard.view
+        |> WorkspaceCard.view operatingSystem
 
 
-view : String -> Bool -> Model -> Html Msg
-view paneId isFocused model =
+view : OperatingSystem -> String -> Bool -> Model -> Html Msg
+view operatingSystem paneId isFocused model =
     div
         [ onClick PaneFocus
         , class "workspace-pane"
@@ -632,5 +684,5 @@ view paneId isFocused model =
         , classList [ ( "workspace-pane_focused", isFocused ) ]
         ]
         (model.workspaceItems
-            |> WorkspaceItems.mapToList (viewItem model.definitionSummaryTooltip)
+            |> WorkspaceItems.mapToList (viewItem operatingSystem model.collapsedItems model.definitionSummaryTooltip)
         )

--- a/src/Code2/Workspace/WorkspacePanes.elm
+++ b/src/Code2/Workspace/WorkspacePanes.elm
@@ -224,14 +224,14 @@ subscriptions model =
 -- VIEW
 
 
-view : Model -> Html Msg
-view model =
+view : OperatingSystem -> Model -> Html Msg
+view operatingSystem model =
     let
         left isFocused =
-            Html.map LeftPaneMsg (WorkspacePane.view "workspace-pane_left" isFocused model.left)
+            Html.map LeftPaneMsg (WorkspacePane.view operatingSystem "workspace-pane_left" isFocused model.left)
 
         right isFocused =
-            Html.map RightPaneMsg (WorkspacePane.view "workspace-pane_right" isFocused model.right)
+            Html.map RightPaneMsg (WorkspacePane.view operatingSystem "workspace-pane_right" isFocused model.right)
 
         paneConfig =
             SplitPane.createViewConfig

--- a/src/Ucm/WorkspaceScreen.elm
+++ b/src/Ucm/WorkspaceScreen.elm
@@ -561,7 +561,12 @@ view appContext model =
                         window_
 
         content =
-            [ Html.map WorkspacePanesMsg (WorkspacePanes.view model.panes) ]
+            [ Html.map WorkspacePanesMsg
+                (WorkspacePanes.view
+                    appContext.operatingSystem
+                    model.panes
+                )
+            ]
     in
     window__
         |> Window.withTitlebarLeft (titlebarLeft model)

--- a/src/Window.elm
+++ b/src/Window.elm
@@ -24,7 +24,7 @@ import UI.Click as Click
 import UI.Divider as Divider
 import UI.Icon as Icon
 import UI.KeyboardShortcut as KeyboardShortcut
-import UI.KeyboardShortcut.Key as Key
+import UI.KeyboardShortcut.Key as Key exposing (letter)
 import UI.KeyboardShortcut.KeyboardEvent as KeyboardEvent
 import UI.Modal as Modal exposing (Modal)
 import UI.Tooltip as Tooltip
@@ -579,17 +579,11 @@ keyboardShortcutsModal appContext =
         chord key1 key2 =
             KeyboardShortcut.Chord key1 key2
 
-        key k =
-            KeyboardShortcut.Sequence Nothing k
-
-        letter k =
-            k Key.Lower
-
         windowNav =
             group "Window navigation"
                 [ command "Toggle sidebar" [ win (letter Key.S), chord Key.Meta (letter Key.B), chord Key.Ctrl (letter Key.B) ]
-                , command "Toggle project picker" [ win (letter Key.P) ]
-                , command "Toggle branch picker" [ win (letter Key.B) ]
+                , command "Show project picker" [ win (letter Key.P) ]
+                , command "Show branch picker" [ win (letter Key.B) ]
                 , command "Toggle right pane" [ win (letter Key.R) ]
                 , command "Focus right pane" [ win (letter Key.L), win Key.ArrowRight ]
                 , command "Focus left pane" [ win (letter Key.H), win Key.ArrowLeft ]
@@ -597,17 +591,19 @@ keyboardShortcutsModal appContext =
 
         paneNav =
             group "Pane navigation"
-                [ command "Move focus up" [ key Key.ArrowUp, key (letter Key.K) ]
-                , command "Move focus down" [ key Key.ArrowDown, key (letter Key.J) ]
+                [ command "Move focus up" [ single Key.ArrowUp, single (letter Key.K) ]
+                , command "Move focus down" [ single Key.ArrowDown, single (letter Key.J) ]
                 , command "Move card up" [ chord Key.Shift Key.ArrowUp, chord Key.Shift (letter Key.K) ]
                 , command "Move card down" [ chord Key.Shift Key.ArrowDown, chord Key.Shift (letter Key.J) ]
+                , command "Toggle fold for focused" [ single (letter Key.Z) ]
+                , command "Toggle fold for all cards" [ chord Key.Shift (letter Key.Z) ]
                 , command "Close focused card" [ single (letter Key.X) ]
                 , command "Close all cards" [ chord Key.Shift (letter Key.X) ]
                 ]
 
         other =
             group "Other"
-                [ command "Command palette / Search" [ key Key.ForwardSlash, chord Key.Meta (letter Key.K), chord Key.Ctrl (letter Key.K) ]
+                [ command "Command palette / Search" [ single Key.ForwardSlash, chord Key.Meta (letter Key.K), chord Key.Ctrl (letter Key.K) ]
                 ]
 
         content =

--- a/src/css/code2/workspace/workspace-card.css
+++ b/src/css/code2/workspace/workspace-card.css
@@ -12,6 +12,25 @@
   z-index: var(--layer-base);
   transition: all 0.2s;
 
+  & .tooltip-with-shortcut {
+    display: flex;
+    flex-direction: row;
+    gap: 0.5rem;
+    align-items: center;
+  }
+
+  & .workspace-card_foldable-content {
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+    padding: 0;
+    transition: height 0.2s ease-in-out;
+    overflow: hidden;
+    width: 100%;
+    height: auto;
+    height: calc-size(auto, size);
+  }
+
   & .workspace-card_titlebar {
     display: flex;
     flex-direction: row;
@@ -21,10 +40,11 @@
     justify-content: space-between;
     padding: 0.5rem 0.75rem;
     height: 2.5rem;
-    border-bottom: 1px solid var(--c-workspace-card_border);
     font-size: var(--font-size-medium);
     color: var(--u-color_text_subdued);
     position: relative;
+    transition: none;
+    border-bottom: 1px solid var(--c-workspace-card_border);
 
     & .subdued {
       color: var(--u-color_text_very-subdued);
@@ -40,6 +60,15 @@
     & .workspace-card_titlebar_right {
       position: absolute;
       right: 0.325rem;
+
+      & .tooltip {
+        margin-top: 0.5rem;
+        margin-left: 2rem;
+
+        & .tooltip-bubble {
+          padding: 0.25rem;
+        }
+      }
     }
 
     & .workspace-card_title {
@@ -113,6 +142,10 @@
   }
 }
 
+.workspace-card:hover {
+  z-index: var(--layer-floating-controls);
+}
+
 .workspace-card:not(.focused):hover {
   --c-workspace-card_border: var(--u-color_border);
   --c-workspace-card_background: var(--u-color_container_selected);
@@ -124,6 +157,21 @@
 
 .workspace-card .definition-doc aside {
   right: -16.5rem;
+}
+
+.workspace-card.folded {
+  border-radius: var(--border-radius-base);
+
+  & .workspace-card_foldable-content {
+    height: 0;
+  }
+
+  &.folded .workspace-card_titlebar,
+  & .workspace-card_titlebar {
+    border-bottom: 1px solid transparent;
+    transition: border 0.2s ease-in-out 0.2s;
+    border-radius: var(--border-radius-base);
+  }
 }
 
 @container workspace-pane (max-width: 968px) {

--- a/src/css/code2/workspace/workspace-card.css
+++ b/src/css/code2/workspace/workspace-card.css
@@ -55,6 +55,32 @@
       flex-direction: row;
       gap: 0.5rem;
       align-items: center;
+
+      & .copy-on-click {
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+        gap: 0.25rem;
+
+        & .copy-on-click_success {
+          margin-top: 3px;
+
+          & .icon {
+            color: var(--u-color_positive_icon-on-element_subdued);
+          }
+        }
+      }
+
+      & .tooltip {
+        margin-top: 0.5rem;
+        margin-left: -0.5rem;
+
+        & .tooltip-bubble {
+          height: 2.25rem;
+          display: flex;
+          align-items: center;
+        }
+      }
     }
 
     & .workspace-card_titlebar_right {
@@ -66,7 +92,9 @@
         margin-left: 2rem;
 
         & .tooltip-bubble {
-          padding: 0.25rem;
+          height: 2.25rem;
+          display: flex;
+          align-items: center;
         }
       }
     }


### PR DESCRIPTION
Add new controls to the titlebars of WorkspaceCard, via a new module: `WorkspaceCardTitlebarButton` with tooltip support and keyboard shortcuts for the new "fold" control:
`z` to toggle fold on the selected card and `Shift`+`z` to toggle fold on all open cards in a pane.