### PR TITLE
Add namespace dropdown button to cards

### DIFF
--- a/elm-git.json
+++ b/elm-git.json
@@ -1,7 +1,7 @@
 {
     "git-dependencies": {
         "direct": {
-            "https://github.com/unisonweb/ui-core": "0e0ba00113beb947a101e8109ad72bc49327dd21"
+            "https://github.com/unisonweb/ui-core": "d233e9da610ba81f21d9e303aed6ed25189fa95d"
         },
         "indirect": {}
     }

--- a/src/Code2/Workspace/DefinitionItem.elm
+++ b/src/Code2/Workspace/DefinitionItem.elm
@@ -51,8 +51,8 @@ toLib defItem =
                 _ ->
                     Nothing
 
-        toLib_ info =
-            case info.namespace of
+        toLib_ info_ =
+            case info_.namespace of
                 Just n ->
                     fqnToLib n
 
@@ -65,36 +65,16 @@ toLib defItem =
                             else
                                 fqnToLib n
                     in
-                    List.foldl f Nothing info.otherNames
+                    List.foldl f Nothing info_.otherNames
     in
-    case defItem of
-        TermItem (Term.Term _ _ { info }) ->
-            toLib_ info
-
-        TypeItem (Type.Type _ _ { info }) ->
-            toLib_ info
-
-        AbilityConstructorItem (AbilityConstructor _ { info }) ->
-            toLib_ info
-
-        DataConstructorItem (DataConstructor _ { info }) ->
-            toLib_ info
+    defItem
+        |> info
+        |> toLib_
 
 
 name : DefinitionItem -> FQN
 name defItem =
-    case defItem of
-        TermItem (Term.Term _ _ { info }) ->
-            info.name
-
-        TypeItem (Type.Type _ _ { info }) ->
-            info.name
-
-        AbilityConstructorItem (AbilityConstructor _ { info }) ->
-            info.name
-
-        DataConstructorItem (DataConstructor _ { info }) ->
-            info.name
+    defItem |> info |> .name
 
 
 hash : DefinitionItem -> Hash
@@ -141,6 +121,32 @@ isDoc defItem =
             False
 
 
+info : DefinitionItem -> Info.Info
+info defItem =
+    case defItem of
+        TermItem (Term.Term _ _ details) ->
+            details.info
+
+        TypeItem (Type.Type _ _ details) ->
+            details.info
+
+        AbilityConstructorItem (AbilityConstructor _ details) ->
+            details.info
+
+        DataConstructorItem (DataConstructor _ details) ->
+            details.info
+
+
+namespace : DefinitionItem -> Maybe FQN
+namespace defItem =
+    defItem |> info |> .namespace
+
+
+otherNames : DefinitionItem -> List FQN
+otherNames defItem =
+    defItem |> info |> .otherNames
+
+
 
 -- JSON DECODERS
 
@@ -163,11 +169,11 @@ decodeTypeDetails :
         }
 decodeTypeDetails =
     let
-        make cat name_ otherNames source doc =
+        make cat name_ otherNames_ source doc =
             { category = cat
             , doc = doc
             , name = name_
-            , otherNames = otherNames
+            , otherNames = otherNames_
             , source = source
             }
     in
@@ -211,10 +217,10 @@ decodeTermDetails :
         }
 decodeTermDetails =
     let
-        make cat name_ otherNames source doc =
+        make cat name_ otherNames_ source doc =
             { category = cat
             , name = name_
-            , otherNames = otherNames
+            , otherNames = otherNames_
             , source = source
             , doc = doc
             }

--- a/src/Code2/Workspace/DefinitionWorkspaceItemState.elm
+++ b/src/Code2/Workspace/DefinitionWorkspaceItemState.elm
@@ -10,4 +10,10 @@ type DefinitionItemTab
 
 type alias DefinitionWorkspaceItemState =
     { activeTab : DefinitionItemTab
+    , namespaceDropdownIsOpen : Bool
     }
+
+
+init : DefinitionItemTab -> DefinitionWorkspaceItemState
+init tab =
+    { activeTab = tab, namespaceDropdownIsOpen = False }

--- a/src/Code2/Workspace/WorkspacePanes.elm
+++ b/src/Code2/Workspace/WorkspacePanes.elm
@@ -228,6 +228,7 @@ type alias PanesConfig =
     { operatingSystem : OperatingSystem
     , withDependents : Bool
     , withDependencies : Bool
+    , withNamespaceDropdown : Bool
     }
 
 
@@ -240,6 +241,7 @@ view cfg model =
             , withDependencies = cfg.withDependencies
             , paneId = paneId
             , isFocused = isFocused
+            , withNamespaceDropdown = cfg.withNamespaceDropdown
             }
 
         left isFocused =

--- a/src/Ucm/WorkspaceScreen.elm
+++ b/src/Ucm/WorkspaceScreen.elm
@@ -564,10 +564,16 @@ view appContext model =
             { operatingSystem = appContext.operatingSystem
             , withDependents = False
             , withDependencies = False
+            , withNamespaceDropdown = False
             }
 
         content =
-            [ Html.map WorkspacePanesMsg (WorkspacePanes.view panesConfig model.panes) ]
+            [ Html.map WorkspacePanesMsg
+                (WorkspacePanes.view
+                    panesConfig
+                    model.panes
+                )
+            ]
     in
     window__
         |> Window.withTitlebarLeft (titlebarLeft model)

--- a/src/css/code2/workspace/workspace-card.css
+++ b/src/css/code2/workspace/workspace-card.css
@@ -62,10 +62,19 @@
         gap: 0.25rem;
 
         & .copy-on-click_success {
-          margin-top: 3px;
+          position: absolute;
+          background: var(--u-color_positive_element_subdued);
+          width: 1.5rem;
+          height: 1.5rem;
+          border-radius: 4px;
+          display: flex;
+          line-height: 1;
+          align-items: center;
+          justify-content: center;
 
           & .icon {
             color: var(--u-color_positive_icon-on-element_subdued);
+            font-size: var(--font-size-base);
           }
         }
       }

--- a/src/css/code2/workspace/workspace-definition-item-card.css
+++ b/src/css/code2/workspace/workspace-definition-item-card.css
@@ -1,4 +1,59 @@
 .workspace-card.workspace-definition-item-card {
+  & .workspace-definition-item-card_other-names {
+    & .workspace-definition-item-card_other-names_button {
+      width: 1.5rem;
+      height: 1.5rem;
+      border-radius: var(--border-radius-base);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+
+      &:hover {
+        & .icon {
+          color: var(--u-color_icon-on-action_hovered);
+        }
+      }
+    }
+
+    & .tooltip {
+      & .tooltip-bubble {
+        height: auto;
+      }
+    }
+  }
+
+  & .workspace-definition-item-card_other-names_list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+
+    & .aka {
+      color: var(--u-color_text_subdued);
+    }
+
+    & .aka,
+    & .other-name {
+      display: flex;
+      line-height: 1;
+      padding: 0.25rem 0;
+    }
+
+    & .other-name {
+      flex-direction: row;
+      gap: 0.25rem;
+      align-items: center;
+
+      & .icon {
+        color: var(--u-color_icon_subdued);
+      }
+
+      & .fully-qualified-name {
+        height: auto;
+        padding: 0;
+      }
+    }
+  }
+
   & .definition-hash {
     margin-right: 0.75rem;
     padding: 0 0.5rem;
@@ -7,6 +62,7 @@
     display: flex;
     flex-direction: row;
     align-items: center;
+    transition: all 0.2s;
 
     & .tooltip {
       margin-top: calc(0.25rem - 1px);

--- a/src/css/unison-dark.css
+++ b/src/css/unison-dark.css
@@ -242,9 +242,9 @@ body.unison-dark {
   --u-color_positive_element: var(--color-green-1);
   --u-color_positive_text-on-element: var(--color-gray-11);
   --u-color_positive_icon-on-element: var(--color-gray-11);
-  --u-color_positive_element_subdued: var(--color-green-5);
+  --u-color_positive_element_subdued: var(--color-green-0);
   --u-color_positive_text-on-element_subdued: var(--u-color_text);
-  --u-color_positive_icon-on-element_subdued: var(--color-green-1);
+  --u-color_positive_icon-on-element_subdued: var(--color-green-4);
 
   /* [x] */
   --u-color_working_element: var(--color-purple-5);


### PR DESCRIPTION
Extend WorkspaceDefinitionItemCard with a new namespace dropdown for changing perspective and finding within the namespace of the definition (this mirrors the behavior of the old namespace). Make it optional, such that we can enable it on Share, but not (yet) in UCM Desktop.

Also add the "other names" feature from the old workspace to definition cards.